### PR TITLE
Increased API query limit

### DIFF
--- a/BotHunter.py
+++ b/BotHunter.py
@@ -91,7 +91,7 @@ def cli():
 
 
 
-    gh = Github(args.key)
+    gh = Github(args.key, per_page=100)
     df = pd.DataFrame(columns=columns)
 
     if args.u != None:


### PR DESCRIPTION
Increased API query limit from 30 (default) to 100. This modification is done by changing PyGitHub's argument "per_page=100". This will save some GitHub API resource.